### PR TITLE
feat: use f_auto,q_auto

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -20,7 +20,7 @@ describe("imageCloudinaryRemarkVisitorFactory", () => {
 		imageCloudinaryRemarkVisitor(node);
 
 		expect(node.properties.src).toBe(
-			"https://res.cloudinary.com/demo/image/fetch/https://some.website.com/cat.gif"
+			"https://res.cloudinary.com/demo/image/fetch/f_auto,q_auto/https://some.website.com/cat.gif"
 		);
 	});
 
@@ -38,7 +38,7 @@ describe("imageCloudinaryRemarkVisitorFactory", () => {
 		imageCloudinaryRemarkVisitor(node);
 
 		expect(node.value).toBe(
-			'<img src={`https://res.cloudinary.com/demo/image/fetch/https://blog.johnnyreilly.com${require("!/workspaces/blog.johnnyreilly.com/blog-website/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[hash].[ext]&fallback=/workspaces/blog.johnnyreilly.com/blog-website/node_modules/file-loader/dist/cjs.js!./bower-with-the-long-paths.png").default}`} width="640" height="497" />'
+			'<img src={`https://res.cloudinary.com/demo/image/fetch/f_auto,q_auto/https://blog.johnnyreilly.com${require("!/workspaces/blog.johnnyreilly.com/blog-website/node_modules/url-loader/dist/cjs.js?limit=10000&name=assets/images/[name]-[hash].[ext]&fallback=/workspaces/blog.johnnyreilly.com/blog-website/node_modules/file-loader/dist/cjs.js!./bower-with-the-long-paths.png").default}`} width="640" height="497" />'
 		);
 	});
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,7 +54,7 @@ export function imageCloudinaryRemarkVisitorFactory({
 			// }
 			const url = node.properties.src;
 
-			node.properties.src = `https://res.cloudinary.com/${cloudName}/image/fetch/${url}`;
+			node.properties.src = `https://res.cloudinary.com/${cloudName}/image/fetch/f_auto,q_auto/${url}`;
 		} else if (node.type === "jsx" && node.value?.includes("<img ")) {
 			// handles nodes like this:
 			// {
@@ -67,7 +67,7 @@ export function imageCloudinaryRemarkVisitorFactory({
 				node.value = node.value.replace(
 					srcRegex,
 					// eslint-disable-next-line no-useless-escape
-					` src={${`\`https://res.cloudinary.com/${cloudName}/image/fetch/${baseUrl}\$\{${urlOrRequire}\}\``}}`
+					` src={${`\`https://res.cloudinary.com/${cloudName}/image/fetch/f_auto,q_auto/${baseUrl}\$\{${urlOrRequire}\}\``}}`
 				);
 			}
 		}


### PR DESCRIPTION
This PR implements usage of f_auto / q_auto - thanks to @rebeccapeltz for the suggestion!

> f_auto causes Cloudinary to look at User Agent information in the request header and provides the best image format for the browser or device making the request.  q_auto provides compression that makes the image smaller without creating pixelation.  